### PR TITLE
feat: transitions now animate on every row via requestAnimationFrame

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "tooltip-experiment",
   "version": "0.1.0",
+  "contributors": [
+    "NicholasBingham"
+  ],
   "homepage": "https://EnshaednHiker.github.io/tooltip-experiment",
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "my-app",
+  "name": "tooltip-experiment",
   "version": "0.1.0",
   "homepage": "https://EnshaednHiker.github.io/tooltip-experiment",
   "private": true,

--- a/src/App.css
+++ b/src/App.css
@@ -13,10 +13,10 @@ th {
 table {
   border-collapse: collapse;
   max-width: 600px;
-  margin: 20px;
 }
 
-.table-wrapper {
+.page-wrapper {
   width: 100vw;
   height: 100vh;
+  display: flex;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import { TooltipController } from "./components/TooltipController";
 
 function App() {
   return (
-    <div className="table-wrapper">
+    <div className="page-wrapper">
       <TooltipController>
         <table>
           <thead>

--- a/src/components/TableRow/index.tsx
+++ b/src/components/TableRow/index.tsx
@@ -5,9 +5,15 @@ export const TableRow = ({ index, category, headline }: TableRowProps) => {
 
   return (
     <tr>
-      <td data-tooltip={dataTooltip}>{index + 1}</td>
-      <td data-tooltip={dataTooltip}>{category}</td>
-      <td data-tooltip={dataTooltip}>{headline}</td>
+      <td data-tooltip={dataTooltip} data-row={index}>
+        {index + 1}
+      </td>
+      <td data-tooltip={dataTooltip} data-row={index}>
+        {category}
+      </td>
+      <td data-tooltip={dataTooltip} data-row={index}>
+        {headline}
+      </td>
     </tr>
   );
 };

--- a/src/components/TooltipController/index.tsx
+++ b/src/components/TooltipController/index.tsx
@@ -2,107 +2,220 @@ import {
   MouseEventHandler,
   PropsWithChildren,
   useCallback,
+  useEffect,
   useRef,
   useState,
 } from "react";
 
 import "./styles.css";
 
-const DURATION_LEAVE = "2s";
-const DURATION = "0.3s";
+const TOOLTIP_CLASSNAME = "tooltip";
+const DURATION_LEAVE = "3s";
+const DURATION = "1s";
 const OPACITY_VISIBLE = "1";
 const OPACITY_INVISIBLE = "0";
 const CURSOR_HELP = "help";
 const CURSOR_AUTO = "auto";
+const KEYFRAME_POP_IN = "tooltip-pop-in";
+const KEYFRAME_POP_OUT = "tooltip-pop-out";
+const INITIAL_ROW_VALUE = "initial";
+
+type Keyframes = typeof KEYFRAME_POP_IN | typeof KEYFRAME_POP_OUT;
+type Duration = typeof DURATION_LEAVE | typeof DURATION;
+
+const cancelAnimation = function (requestId: number | undefined) {
+  if (requestId) {
+    window.cancelAnimationFrame(requestId);
+    // animation frames increment numerically, and sometimes the last animation frame can get stuck when moving the mouse quickly
+    // removing the 2nd to last frame seems to be a better experience
+    window.cancelAnimationFrame(requestId - 1);
+  }
+  return requestId;
+};
 
 export const TooltipController = ({ children }: PropsWithChildren<any>) => {
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const topTooltipRef = useRef<HTMLDivElement>(null);
+  const bottomTooltipRef = useRef<HTMLDivElement>(null);
 
   const [tooltipData, setTooltipData] = useState<string | undefined>();
   const [tooltipOpacity, setTooltipOpacity] = useState<
     typeof OPACITY_INVISIBLE | typeof OPACITY_VISIBLE
   >(OPACITY_INVISIBLE);
-  const [tooltipDuration, setTooltipDuration] = useState<
-    typeof DURATION_LEAVE | typeof DURATION
-  >(DURATION);
   const [tooltipCursor, setTooltipCursor] = useState<
     typeof CURSOR_AUTO | typeof CURSOR_HELP
-  >(CURSOR_HELP);
+  >(CURSOR_AUTO);
   const [tooltipTop, setTooltipTop] = useState<number>(0);
   const [tooltipLeft, setTooltipLeft] = useState<number>(0);
+  const [row, setRow] = useState<string>(INITIAL_ROW_VALUE);
+  const [cursorIsInTableHeadRow, setIsCursorInTableHeadRow] =
+    useState<boolean>(true);
+  const [animationState, setAnimationState] = useState<
+    "reset" | "restart" | "restart-leave"
+  >("reset");
+
+  const [animationRequestId, setAnimationRequestId] = useState<
+    number | undefined
+  >();
 
   const handleOnMouseLeave = useCallback<MouseEventHandler<HTMLDivElement>>(
     (event) => {
-      setTooltipOpacity(OPACITY_INVISIBLE);
-      setTooltipDuration(DURATION_LEAVE);
       setTooltipCursor(CURSOR_AUTO);
+      setRow(INITIAL_ROW_VALUE);
+      if (!cursorIsInTableHeadRow) {
+        setAnimationState("restart-leave");
+      }
     },
-    []
+    [cursorIsInTableHeadRow]
   );
 
   const handleOnMouseOver = useCallback<MouseEventHandler<HTMLDivElement>>(
     (event) => {
       const eventTarget = event.target as HTMLElement;
       const tooltipData = eventTarget.dataset?.tooltip;
+      const currentRow = eventTarget.dataset?.row ?? "";
+
+      const isInTableHead = eventTarget.nodeName === "TH";
+      const isInTableCell = eventTarget.nodeName === "TD";
 
       const outerTableDimensions = wrapperRef.current?.getBoundingClientRect();
       const currentTableCellDimensions = eventTarget.getBoundingClientRect();
 
+      if (currentRow !== row) {
+        setRow(currentRow);
+      }
+
+      if (currentRow !== row && isInTableCell && tooltipData) {
+        setAnimationState("restart");
+        setTooltipCursor(CURSOR_HELP);
+        setIsCursorInTableHeadRow(false);
+      }
+
+      if (
+        isInTableHead &&
+        // when entering table head on initial page load we do not start an animation,
+        // only when leaving from in a table cell to the table head should kick off an animation
+        row !== "initial" &&
+        currentRow !== row &&
+        !tooltipData
+      ) {
+        setAnimationState("restart-leave");
+        setTooltipCursor(CURSOR_AUTO);
+        setIsCursorInTableHeadRow(true);
+      }
+
       if (tooltipData) {
         setTooltipData(tooltipData);
-        setTooltipOpacity(OPACITY_VISIBLE);
-        setTooltipDuration(DURATION);
-        setTooltipCursor(CURSOR_HELP);
+      }
 
-        // make sure we don't set the tooltip on top of the table headings
-        if (wrapperRef.current !== eventTarget) {
-          setTooltipTop(
-            currentTableCellDimensions.top -
-              (outerTableDimensions?.top ?? 0) -
-              8
-          );
-          setTooltipLeft(
-            currentTableCellDimensions.left -
-              (outerTableDimensions?.left ?? 0) +
-              eventTarget.offsetWidth / 2
-          );
-        }
-      } else {
-        setTooltipOpacity(OPACITY_INVISIBLE);
-        setTooltipDuration(DURATION_LEAVE);
-        setTooltipCursor(CURSOR_AUTO);
+      // make sure we don't set the tooltip on top of the table headings
+      if (isInTableCell && tooltipData) {
+        setTooltipTop(
+          currentTableCellDimensions.top - (outerTableDimensions?.top ?? 0) - 8
+        );
+        setTooltipLeft(
+          currentTableCellDimensions.left -
+            (outerTableDimensions?.left ?? 0) +
+            eventTarget.offsetWidth / 2
+        );
       }
     },
-    []
+    [row]
   );
 
-  const handleOnMouseEnter = useCallback<MouseEventHandler<HTMLDivElement>>(
-    (event) => {
-      setTooltipOpacity(OPACITY_VISIBLE);
-      setTooltipDuration(DURATION);
-      setTooltipCursor(CURSOR_HELP);
+  const handleRequestAnimation = useCallback(
+    (animationKeyFrame: Keyframes, animationDuration: Duration) => {
+      if (animationKeyFrame === KEYFRAME_POP_IN) {
+        setTooltipOpacity(OPACITY_INVISIBLE);
+      } else {
+        setTooltipOpacity(OPACITY_VISIBLE);
+      }
+
+      // cancel any currently running animations before starting a new one.
+      // might not be strictly necessary since we're always resetting opacity to the the starting state of both animations
+      cancelAnimation(animationRequestId);
+
+      const topTooltipElement = topTooltipRef.current as HTMLElement;
+      const bottomTooltipElement = bottomTooltipRef.current as HTMLElement;
+
+      // by setting the animation style to none, we strip out the existing animation,
+      // this allows a new animation to placed on the elements and makes it so any animation
+      // can be reset over and over again without removing elements from the DOM or removing and placing classNames
+      topTooltipElement.style.animation = "none";
+      bottomTooltipElement.style.animation = "none";
+
+      if (topTooltipElement && bottomTooltipElement) {
+        const requestId = window.requestAnimationFrame(function () {
+          topTooltipElement.style.animation = `${animationKeyFrame} ${animationDuration} both`;
+          topTooltipElement.style.animationDelay = "100ms";
+
+          bottomTooltipElement.style.animation = `${animationKeyFrame} ${animationDuration} both`;
+          bottomTooltipElement.style.animationDelay = "100ms";
+        });
+
+        return requestId;
+      }
+      return undefined;
     },
-    []
+    [animationRequestId]
   );
+
+  useEffect(() => {
+    if (animationState === "reset") {
+      // reset exists to allow animationState a state to return to after tripping a new animation
+      // and to allow this useEffect to be tripped by state changes going from reset => restart-leave or reset => restart.
+      // because this state resets things, we don't actually need to do anything here
+    } else if (animationState === "restart") {
+      const currentAnimationRequestId = handleRequestAnimation(
+        KEYFRAME_POP_IN,
+        DURATION
+      );
+      setAnimationRequestId(currentAnimationRequestId);
+      setAnimationState("reset");
+    } else if ("restart-leave") {
+      const currentAnimationRequestId = handleRequestAnimation(
+        KEYFRAME_POP_OUT,
+        DURATION_LEAVE
+      );
+      setAnimationRequestId(currentAnimationRequestId);
+      setAnimationState("reset");
+    }
+  }, [animationState, handleRequestAnimation]);
 
   return (
-    <div
-      className="tooltip"
-      data-tooltip={tooltipData}
-      onMouseEnter={handleOnMouseEnter}
-      onMouseLeave={handleOnMouseLeave}
-      onMouseOver={handleOnMouseOver}
-      ref={wrapperRef}
-      style={{
-        // @ts-ignore --tooltip custom css properties not allowed
-        "--tooltip-opacity": tooltipOpacity,
-        "--tooltip-duration": tooltipDuration,
-        "--tooltip-cursor": tooltipCursor,
-        "--tooltip-left-position": `${tooltipLeft}px`,
-        "--tooltip-top-position": `${tooltipTop}px`,
-      }}
-    >
-      {children}
+    <div className="table-wrapper">
+      <div
+        className={TOOLTIP_CLASSNAME}
+        data-tooltip={tooltipData}
+        onMouseLeave={handleOnMouseLeave}
+        onMouseOver={handleOnMouseOver}
+        ref={wrapperRef}
+        style={{
+          // @ts-ignore --tooltip custom css properties not allowed
+          "--tooltip-opacity": tooltipOpacity,
+          "--tooltip-cursor": tooltipCursor,
+          "--tooltip-left-position": `${tooltipLeft}px`,
+          "--tooltip-top-position": `${tooltipTop}px`,
+        }}
+      >
+        <div
+          className="tooltip-top"
+          // if the tooltip exposes new information, we'd want to announce that information to screen reader users
+          role="alert"
+          tabIndex={-1}
+          aria-hidden={true}
+          ref={topTooltipRef}
+        >
+          {tooltipData}
+        </div>
+        <div
+          className="tooltip-bottom"
+          tabIndex={-1}
+          aria-hidden={true}
+          ref={bottomTooltipRef}
+        />
+        {children}
+      </div>
     </div>
   );
 };

--- a/src/components/TooltipController/styles.css
+++ b/src/components/TooltipController/styles.css
@@ -1,20 +1,38 @@
+@keyframes tooltip-pop-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes tooltip-pop-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
 .tooltip {
   position: relative;
   cursor: var(--tooltip-cursor);
   width: fit-content;
-  margin: auto 40px;
+  margin: auto 0;
 }
 
-.tooltip::before,
-.tooltip::after {
+.tooltip-bottom,
+.tooltip-top {
   position: absolute;
   left: var(--tooltip-left-position);
   top: var(--tooltip-top-position);
   opacity: var(--tooltip-opacity);
-  transition: all ease var(--tooltip-duration);
+  will-change: top, left, opacity;
 }
 
-.tooltip::before {
+.tooltip-bottom {
   content: "";
   border-width: 10px 8px 0 8px;
   border-style: solid;
@@ -22,8 +40,7 @@
   margin-left: -8px;
 }
 
-.tooltip::after {
-  content: attr(data-tooltip);
+.tooltip-top {
   background: rgba(0, 0, 0, 0.9);
   transform: translateY(-100%);
   font-size: 14px;
@@ -32,4 +49,8 @@
   border-radius: 10px;
   color: #eee;
   padding: 14px;
+}
+
+.table-wrapper {
+  margin: 40px auto;
 }


### PR DESCRIPTION
- the animations now restart on every row change
- the animations and cursor changes do not fire in the table head
- various layout style fixes
- semantic use of the requestAnimationFrame windows API allows animations to be reset
- updated app name in the package.json file
- added contributors